### PR TITLE
Initialize authentication to a failed promise.

### DIFF
--- a/help-esb.js
+++ b/help-esb.js
@@ -23,7 +23,7 @@
   // need to [login](#helpesb-client-login) before doing anything over the
   // connection.
   //
-  //     var client = Esb.Client('tcp://example.com:1234');
+  //     var client = new Esb.Client('tcp://example.com:1234');
   //     client.login('clientName');
   //     client.subscribe('subscriptionChannel1');
   //     client.on('type.error', console.error);
@@ -33,7 +33,7 @@
   //
   // Or using the RPC conventions:
   //
-  //     var client = Esb.Client('tcp://example.com:1234');
+  //     var client = new Esb.Client('tcp://example.com:1234');
   //     client.login('clientName');
   //     client.rpcReceive('subscriptionChannel1', function(data) {
   //       // Process data

--- a/help-esb.js
+++ b/help-esb.js
@@ -46,7 +46,7 @@
     this._connect(uri);
 
     // Start with no authentication and no subscriptions.
-    this._authentication = null;
+    this._authentication = Promise.reject('Attempted to send data through the ESB before authenticating');
     this._subscriptions = {};
     this._login = null;
     this._options = _.extend({debug: false}, options);
@@ -245,7 +245,7 @@
 
   // Reauthenticates and resubscribes to the socket using the given data.
   HelpEsb.Client.prototype._resubscribe = function(login, subscriptions) {
-    this._authentication = null;
+    this._authentication = Promise.reject('Attempted to send data through the ESB before authenticating');
     this._subscriptions = {};
 
     if (login !== null) {

--- a/help-esb.js
+++ b/help-esb.js
@@ -196,7 +196,7 @@
     this.emit('socket.close');
     this._socket.removeAllListeners('close');
     this._socket.end();
-  }
+  };
 
   // ---
   // ### Private Methods
@@ -253,7 +253,7 @@
       this.login(login);
       subscriptions.forEach(this.subscribe, this);
     }
-  }
+  };
 
   // Format the packet for the ESB and send it over the socket.  JSON encodes
   // the message and appends a newline as the delimiter between messages.


### PR DESCRIPTION
The error message being returned when trying to send before login was a bit confusing.  This clears up what is happening.