### PR TITLE
Fix forgotten auth promise rejection.

### DIFF
--- a/examples/read.js
+++ b/examples/read.js
@@ -1,5 +1,5 @@
 var HelpEsb = require('../help-esb');
-var client = new HelpEsb.Client(process.env.ESB);
+var client = new HelpEsb.Client(process.env.ESB, {debug: true});
 client.login('foo');
 client.subscribe('asdf');
 

--- a/examples/rpcReceive.js
+++ b/examples/rpcReceive.js
@@ -1,6 +1,6 @@
 var HelpEsb = require('../help-esb');
 var Promise = require('bluebird');
-var client = new HelpEsb.Client(process.env.ESB);
+var client = new HelpEsb.Client(process.env.ESB, {debug: true});
 client.login('rpcReceive');
 
 client.rpcReceive('rpc-test', function(data) {

--- a/examples/rpcSend.js
+++ b/examples/rpcSend.js
@@ -1,5 +1,5 @@
 var HelpEsb = require('../help-esb');
-var client = new HelpEsb.Client(process.env.ESB);
+var client = new HelpEsb.Client(process.env.ESB, {debug: true});
 client.login('rpcSend');
 
 client.rpcSend('rpc-test', {name: 'nubs'})

--- a/examples/write.js
+++ b/examples/write.js
@@ -1,5 +1,5 @@
 var HelpEsb = require('../help-esb');
-var client = new HelpEsb.Client(process.env.ESB);
+var client = new HelpEsb.Client(process.env.ESB, {debug: true});
 client.login('bar');
 client.send('asdf', {name: 'cool guy'}).finally(client.close.bind(client));
 


### PR DESCRIPTION
Bluebird is a bit funny when it comes to these unhandled promises.  It likes to dump stack traces very greedily, so while the code worked before, it erroneously dumped an error all the time.  Therefore we need to make sure we are only creating the rejected promise when we need it to actually fail things.