### PR TITLE
Convert library from using data/meta pairs to a Message object and add inre to headers.

### DIFF
--- a/examples/read.js
+++ b/examples/read.js
@@ -3,9 +3,9 @@ var client = new HelpEsb.Client(process.env.ESB, {debug: true});
 client.login('foo');
 client.subscribe('asdf');
 
-client.on('group.asdf', function(data) {
+client.on('group.asdf', function(message) {
   console.log('Received data:');
-  console.log(data);
+  console.log(message.toJSON());
 });
 
 client.on('type.error', function(err) {

--- a/examples/rpcReceive.js
+++ b/examples/rpcReceive.js
@@ -3,8 +3,8 @@ var Promise = require('bluebird');
 var client = new HelpEsb.Client(process.env.ESB, {debug: true});
 client.login('rpcReceive');
 
-client.rpcReceive('rpc-test', function(data) {
-  return {greeting: 'Hello ' + data.name};
+client.rpcReceive('rpc-test', function(message) {
+  return {greeting: 'Hello ' + message.get('name')};
 });
 
 client.on('type.error', function(err) {

--- a/examples/rpcSend.js
+++ b/examples/rpcSend.js
@@ -4,9 +4,9 @@ client.login('rpcSend');
 
 client.rpcSend('rpc-test', {name: 'nubs'})
   .timeout(5000)
-  .then(function(response) {
+  .then(function(message) {
     console.log('Received response:');
-    console.log(response);
+    console.log(message.toJSON());
   }).catch(function(error) {
     console.warn('Received error:');
     console.warn(error);

--- a/help-esb.js
+++ b/help-esb.js
@@ -11,9 +11,20 @@
     require('url'),
     require('bluebird'),
     require('uuid'),
-    require('lodash')
+    require('lodash'),
+    require('object-path')
   );
-}(this, function(HelpEsb, net, EventEmitter, util, url, Promise, uuid, _) {
+}(this, function(
+  HelpEsb,
+  net,
+  EventEmitter,
+  util,
+  url,
+  Promise,
+  uuid,
+  _,
+  objectPath
+) {
   'use strict';
 
   // ## HelpEsb.Client
@@ -27,16 +38,16 @@
   //     client.login('clientName');
   //     client.subscribe('subscriptionChannel1');
   //     client.on('type.error', console.error);
-  //     client.on('group.subscriptionChannel1', function(data) {
-  //       // Process data
+  //     client.on('group.subscriptionChannel1', function(message) {
+  //       // Process message
   //     });
   //
   // Or using the RPC conventions:
   //
   //     var client = new Esb.Client('tcp://example.com:1234');
   //     client.login('clientName');
-  //     client.rpcReceive('subscriptionChannel1', function(data) {
-  //       // Process data
+  //     client.rpcReceive('subscriptionChannel1', function(message) {
+  //       // Process message
   //       return result;
   //     });
   HelpEsb.Client = function(uri, options) {
@@ -50,6 +61,8 @@
     this._subscriptions = {};
     this._login = null;
     this._options = _.extend({debug: false}, options);
+
+    this.mb = new HelpEsb.MessageBuilder(this);
   };
 
   util.inherits(HelpEsb.Client, EventEmitter);
@@ -64,10 +77,8 @@
   HelpEsb.Client.prototype.login = function(name) {
     this._login = name;
 
-    return this._authentication = this._rpcSend({
-      meta: {type: 'login'},
-      data: {name: name, subscriptions: []}
-    }).timeout(10000);
+    return this._authentication = this._rpcSend(this.mb.login(name))
+      .timeout(10000);
   };
 
   // ### HelpEsb.Client.subscribe
@@ -81,10 +92,7 @@
   HelpEsb.Client.prototype.subscribe = function(group) {
     if (typeof this._subscriptions[group] === 'undefined') {
       this._subscriptions[group] = this._authPromise().then(function() {
-        return this._rpcSend({
-          meta: {type: 'subscribe'},
-          data: {channel: group}
-        }).timeout(10000);
+        return this._rpcSend(this.mb.subscribe(group)).timeout(10000);
       }.bind(this));
     }
 
@@ -92,17 +100,17 @@
   };
 
   // ### HelpEsb.Client.send
-  // Sends a payload message to the ESB with the given data.  Returns a promise
-  // that, like the [subscribe](#helpesb-client-subscribe) call, is fulfilled
-  // when the message is sent, but does not indicate whether the message was
-  // received by the ESB or by any subscribers.  For RPC-esque behavior, use
-  // [rpcSend](#helpesb-client-rpcsend).
+  // Sends a payload message to the ESB with the given message.  Returns a
+  // promise that, like the [subscribe](#helpesb-client-subscribe) call, is
+  // fulfilled when the message is sent, but does not indicate whether the
+  // message was received by the ESB or by any subscribers.  For RPC-esque
+  // behavior, use [rpcSend](#helpesb-client-rpcsend).
   //
   //     client.send('target', {id: 1234, message: 'Hello!'});
-  HelpEsb.Client.prototype.send = function(group, data, replyCallback) {
+  HelpEsb.Client.prototype.send = function(group, message, replyCallback) {
     return this._authPromise().then(function() {
       return this._send(
-        {meta: {type: 'sendMessage', group: group}, data: data},
+        this.mb.send(group, this.mb.coerce(message)),
         replyCallback
       );
     }.bind(this));
@@ -117,15 +125,16 @@
   // Automatically subscribes to the result group for you if not already
   // subscribed.
   //
-  //     client.rpcSend('foo', {name: 'John'}).then(function(response) {
-  //       console.log(response);
-  //     }).catch(function(error) {
-  //       console.error(error);
-  //     });
-  HelpEsb.Client.prototype.rpcSend = function(group, data) {
+  //     client.rpcSend('foo', {name: 'John'})
+  //       .then(function(response) {
+  //         console.log(response.toJSON());
+  //       }).catch(function(error) {
+  //         console.error(error);
+  //       });
+  HelpEsb.Client.prototype.rpcSend = function(group, message) {
     var send = Promise.promisify(HelpEsb.Client.prototype.send).bind(this);
     return this.subscribe(group + '-result').then(function() {
-      return send(group, data).spread(this._checkRpcResult);
+      return send(group, message).then(this._checkRpcResult);
     }.bind(this));
   };
 
@@ -136,56 +145,58 @@
   //
   // Automatically subscribes to the group for you if not already subscribed.
   //
-  //     client.rpcReceive('foo', function(data) {
-  //       return {greeting: 'Hello ' + (data.name || 'Stranger')};
+  //     client.rpcReceive('foo', function(message) {
+  //       return {greeting: 'Hello ' + message.get('name', 'Stranger')};
   //     });
   //
   // If the callback returns a promise, the result of the promise is sent.
   //
-  //     client.rpcReceive('foo', function(data) {
+  //     client.rpcReceive('foo', function(message) {
   //       return request.getAsync('http://www.google.com');
   //     });
   //
   // Errors are also handled and errors are sent as the "reason" through the
   // ESB.
   //
-  //     client.rpcReceive('foo', function(data) {
+  //     client.rpcReceive('foo', function(message) {
   //       throw new Error('Not implemented!');
   //     });
   HelpEsb.Client.prototype.rpcReceive = function(group, cb) {
     this.subscribe(group);
-    this.on('group.' + group, function(data, incomingMeta) {
-      var meta = {type: 'sendMessage', replyTo: incomingMeta.id};
+    this.on('group.' + group, function(message) {
+      var meta = {type: 'sendMessage', replyTo: message.getMeta('id')};
 
       // Link up our reply to the incoming request but on the "result" group.
       var groups = [group + '-result'];
 
       // CC the groups in the incoming messages CC list.
-      if (incomingMeta.cc && typeof incomingMeta.cc.group !== 'undefined') {
-        groups = groups.concat(incomingMeta.cc.group);
+      if (message.hasMeta('cc.group')) {
+        groups = groups.concat(message.getMeta('cc.group'));
       }
 
-      if (typeof incomingMeta.session !== 'undefined') {
-        meta.session = incomingMeta.session;
+      if (message.hasMeta('session')) {
+        meta.session = message.getMeta('session');
       }
 
-      var sendToGroup = function(meta, data, group) {
-        return this._send({meta: _.extend({group: group}, meta), data: data});
+      var sendToGroup = function(message, group) {
+        return this._send(this.mb.send(group, message));
       }.bind(this);
 
-      var sendToAll = function(meta, data) {
-        return Promise.all(groups.map(_.partial(sendToGroup, meta, data)));
+      var sendToAll = function(message) {
+        return Promise.all(groups.map(_.partial(sendToGroup, message)));
       };
 
-      Promise.try(cb.bind({}, data, incomingMeta)).then(function(data) {
-        return sendToAll(_.extend({result: 'SUCCESS'}, meta), data);
+      Promise.try(cb.bind({}, message)).then(function(message) {
+        return sendToAll(
+          this.mb.success(
+            this.mb.extend({meta: meta}, this.mb.coerce(message))
+          )
+        );
       }.bind(this)).catch(function(error) {
         var reason = error instanceof Error ? error.toString() : error;
+        var errorMeta = _.extend({reason: reason}, meta);
 
-        return sendToAll(
-          _.extend({result: 'FAILURE', reason: reason}, meta),
-          data
-        );
+        return sendToAll(this.mb.failure({meta: errorMeta}));
       }.bind(this));
     }.bind(this));
   };
@@ -196,6 +207,25 @@
     this.emit('socket.close');
     this._socket.removeAllListeners('close');
     this._socket.end();
+  };
+
+  // ### HelpEsb.Client.decorateMessage
+  // Formats the message with client-specific values needed by the ESB.  This
+  // includes the `from` key in the meta to reference the logged in client
+  // channel id.
+  //
+  // You probably don't need to call this yourself as it is called by the
+  // `MessageBuilder`.
+  HelpEsb.Client.prototype.decorateMessage = function(message) {
+    if (
+      this._authentication !== null &&
+      this._authentication.isFulfilled() &&
+      this._authentication.value().has('channelId')
+    ) {
+      message.meta.from = this._authentication.value().get('channelId');
+    }
+
+    return message;
   };
 
   // ---
@@ -255,46 +285,47 @@
     }
   };
 
-  // Format the packet for the ESB and send it over the socket.  JSON encodes
+  // Format the message for the ESB and send it over the socket.  JSON encodes
   // the message and appends a newline as the delimiter between messages.
-  HelpEsb.Client.prototype._send = function(packet, replyCallback) {
-    packet = this._massageOutboundPacket(packet);
-
+  HelpEsb.Client.prototype._send = function(message, replyCallback) {
     // Register a callback for replies to this message if a callback is given.
     if (replyCallback) {
-      this.once('replyTo.' + packet.meta.id, _.partial(replyCallback, null));
+      this.once(
+        'replyTo.' + message.getMeta('id'),
+        _.partial(replyCallback, null)
+      );
     }
 
-    return this._sendRaw(JSON.stringify(packet) + '\n');
+    return this._sendRaw(JSON.stringify(message) + '\n');
   };
 
-  // Sends the packet like **_send**, but returns a promise for a response from
-  // some other service.  This uses the autogen message id and relies on the
-  // other service properly publishing a message with a proper replyTo.
-  HelpEsb.Client.prototype._rpcSend = function(packet) {
+  // Sends the message like **_send**, but returns a promise for a response
+  // from some other service.  This uses the autogen message id and relies on
+  // the other service properly publishing a message with a proper replyTo.
+  HelpEsb.Client.prototype._rpcSend = function(message) {
     var send = Promise.promisify(HelpEsb.Client.prototype._send).bind(this);
-    return send(packet).spread(this._checkRpcResult);
+    return send(message).then(this._checkRpcResult);
   };
 
   // Checks an RPC response and fails the promise if the response is not
   // successful.
-  HelpEsb.Client.prototype._checkRpcResult = function(data, meta) {
-    if (meta.result !== 'SUCCESS') {
-      return Promise.reject(meta.reason);
+  HelpEsb.Client.prototype._checkRpcResult = function(message) {
+    if (message.getMeta('result') !== 'SUCCESS') {
+      return Promise.reject(message.getMeta('reason'));
     }
 
-    return Promise.resolve(data);
+    return Promise.resolve(message);
   };
 
   // Wait on the socket connection and once it is avaialable send the given
-  // string data returning a promise of the data being sent.
-  HelpEsb.Client.prototype._sendRaw = function(data) {
+  // string packet returning a promise of the packet being sent.
+  HelpEsb.Client.prototype._sendRaw = function(packet) {
     if (this._options.debug) {
-      console.log('help-esb SENDING', data);
+      console.log('help-esb SENDING', packet);
     }
 
     return this._socketConnection.then(function() {
-      return this._socket.writeAsync(data);
+      return this._socket.writeAsync(packet);
     }.bind(this));
   };
 
@@ -317,9 +348,9 @@
     }
   };
 
-  // Handles a single packet of data.  The data is expected to be JSON, and if
-  // it isn't, a `type.error` event will be emitted.  Otherwise, an event for
-  // each of the meta fields (e.g., `type.error`, `group.someGroup`,
+  // Handles a single packet of data.  The packet is expected to be JSON, and
+  // if it isn't, a `type.error` event will be emitted.  Otherwise, an event
+  // for each of the meta fields (e.g., `type.error`, `group.someGroup`,
   // `replyTo.SOME_ID`) will be emitted.
   //
   // In addition, non-error packets will be emitted to the `*` event and, if no
@@ -333,23 +364,19 @@
       console.log('help-esb RECEIVED', packet);
     }
 
+    var message;
+
     try {
-      packet = JSON.parse(packet);
+      message = new HelpEsb.Message(JSON.parse(packet));
+      if (!message.hasMeta('type')) {
+        throw new Error('Invalid format detected for packet');
+      }
     } catch (e) {
       this.emit('type.error', e);
       return;
     }
 
-    if (
-      typeof packet.meta !== 'object' ||
-      typeof packet.meta.type !== 'string' ||
-      typeof packet.data === 'undefined'
-    ) {
-      this.emit('type.error', 'Invalid format detected for packet', packet);
-      return;
-    }
-
-    // Emits key.value events with the data and meta.  If the value is an
+    // Emits key.value events with the message.  If the value is an
     // array, it iterates over the array and emits events on each value in the
     // array.  Returns true if any of the events were handled.
     var emitKeyValue = function(value, key) {
@@ -359,29 +386,13 @@
         }));
       }
 
-      return this.emit(key + '.' + value, packet.data, packet.meta);
+      return this.emit(key + '.' + value, message);
     }.bind(this);
 
-    this.emit('*', packet.data, packet.meta);
-    if (!_.any(_.map(packet.meta, emitKeyValue))) {
-      this.emit('*.unhandled', packet.data, packet.meta);
+    this.emit('*', message);
+    if (!_.any(_.map(message.getMeta(), emitKeyValue))) {
+      this.emit('*.unhandled', message);
     }
-  };
-
-  // Process the packet to ensure it conforms to the ESB requirements.  Sets
-  // the message id in the metadata for the packet if it wasn't already set.
-  HelpEsb.Client.prototype._massageOutboundPacket = function(packet) {
-    packet.meta.id = packet.meta.id || uuid.v4();
-
-    if (
-      this._authentication !== null &&
-      this._authentication.isFulfilled() &&
-      typeof this._authentication.value().channelId !== 'undefined'
-    ) {
-      packet.meta.from = this._authentication.value().channelId;
-    }
-
-    return packet;
   };
 
   // This will return a failed promise if authentication hasn't been attempted
@@ -389,6 +400,139 @@
   HelpEsb.Client.prototype._authPromise = function() {
     return this._authentication ||
       Promise.reject('Attempted to send data through the ESB before authenticating');
+  };
+
+  // ## HelpEsb.MessageBuilder
+  // The `MessageBuilder` is a helper object that can build a `HelpEsb.Message`
+  // according to standard message types.
+
+  // ### HelpEsb.MessageBuilder *constructor*
+  // Initializes the object with access to the `HelpEsb.Client` instance used
+  // to decorate messages further.
+  HelpEsb.MessageBuilder = function(client) {
+    this._client = client;
+  };
+
+  // ### HelpEsb.MessageBuilder.login
+  // Creates a standard login message for the given client name.
+  HelpEsb.MessageBuilder.prototype.login = function(name) {
+    return new HelpEsb.Message({
+      meta: {type: 'login'},
+      data: {name: name, subscriptions: []}
+    });
+  };
+
+  // ### HelpEsb.MessageBuilder.subscribe
+  // Creates a standard subscribe message for the given group name.
+  HelpEsb.MessageBuilder.prototype.subscribe = function(group) {
+    return this.create({meta: {type: 'subscribe'}, data: {channel: group}});
+  };
+
+  // ### HelpEsb.MessageBuilder.send
+  // Creates a standard `sendMessage` message, extending off of the given
+  // message.
+  HelpEsb.MessageBuilder.prototype.send = function(group, message) {
+    return this.extend({meta: {type: 'sendMessage', group: group}}, message);
+  };
+
+  // ### HelpEsb.MessageBuilder.success
+  // Creates a standard success message which has a result status, extending
+  // off of the given message.
+  HelpEsb.MessageBuilder.prototype.success = function(message) {
+    return this.extend({meta: {result: 'SUCCESS'}}, message);
+  };
+
+  // ### HelpEsb.MessageBuilder.failure
+  // Creates a standard failure message which has a result status, extending
+  // off of the given message.
+  HelpEsb.MessageBuilder.prototype.failure = function(message) {
+    return this.extend({meta: {result: 'FAILURE'}}, message);
+  };
+
+  // ### HelpEsb.MessageBuilder.create
+  // Creates a `HelpEsb.Message` object that has been decorated by the client.
+  HelpEsb.MessageBuilder.prototype.create = function(message) {
+    return new HelpEsb.Message(this._client.decorateMessage(message));
+  };
+
+  // ### HelpEsb.MessageBuilder.build
+  // Creates a `HelpEsb.Message` object that has been decorated by the client
+  // from its constituent data and meta parameters.
+  HelpEsb.MessageBuilder.prototype.build = function(data, meta) {
+    return this.create({meta: meta || {}, data: data || {}});
+  };
+
+  // ### HelpEsb.MessageBuilder.coerce
+  // Coerces the passed argument into a message, returning it as is if it is a
+  // `HelpEsb.Message` object, or building it from its `data` (and optional
+  // `meta`) otherwise.
+  HelpEsb.MessageBuilder.prototype.coerce = function(data, meta) {
+    return data instanceof HelpEsb.Message ? data : this.build(data, meta);
+  };
+
+  // ### HelpEsb.MessageBuilder.extend
+  // Extends a message (`Message` object or POJO) with other message(s).
+  // Returns a new message that is the combined data/meta parts from all of the
+  // passed message arguments.
+  HelpEsb.MessageBuilder.prototype.extend = function(/* object, extension */) {
+    var params = _.map(arguments, function(arg) {
+      return _.clone(arg instanceof HelpEsb.Message ? arg.toJSON() : arg);
+    });
+
+    return this.build(
+      _.extend.apply({}, [{}].concat(_.pluck(params, 'data'))),
+      _.extend.apply({}, [{}].concat(_.pluck(params, 'meta')))
+    );
+  };
+
+  // ## HelpEsb.Message
+  // A data object representing an ESB message.  Also provides some convenience
+  // methods.
+
+  // ### HelpEsb.Message *constructor*
+  // Initiates the message based on the given message object.  Initializes the
+  // meta and data fields appropriately, including adding a message id if one
+  // does not exist.
+  HelpEsb.Message = function(message) {
+    this._data = _.has(message, 'data') ? message.data : {};
+    this._meta = _.extend({id: uuid.v4()}, message.meta);
+  };
+
+  // ### HelpEsb.Message.get
+  // Get the data property with the given dot-delimited path.  For example,
+  //
+  //     message = new HelpEsb.Message({foo: {bar: 'baz'}});
+  //     message.get('foo.bar') === 'baz';
+  //
+  // You can also provide a default value to return instead of `undefined` for
+  // values that don't exist.
+  HelpEsb.Message.prototype.get = function(path, def) {
+    return objectPath.get(this._data, path, def);
+  };
+
+  // ### HelpEsb.Message.getMeta
+  // Like [get](#helpesb-message-get), but for the meta fields.
+  HelpEsb.Message.prototype.getMeta = function(path, def) {
+    return objectPath.get(this._meta, path, def);
+  };
+
+  // ### HelpEsb.Message.has
+  // Checks for the existence of the data proper with the given dot-delimited
+  // path.
+  HelpEsb.Message.prototype.has = function(path) {
+    return objectPath.has(this._data, path);
+  };
+
+  // ### HelpEsb.Message.hasMeta
+  // Like [has](#helpesb-message-has), but for the meta fields.
+  HelpEsb.Message.prototype.hasMeta = function(path) {
+    return objectPath.has(this._meta, path);
+  };
+
+  // ### HelpEsb.Message.toJSON
+  // Converts the message into its canonical form for JSON serialization.
+  HelpEsb.Message.prototype.toJSON = function() {
+    return {meta: this._meta, data: this._data};
   };
 
   return HelpEsb;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "help-esb",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A client for the Help.com team's ESB.",
   "main": "help-esb.js",
   "author": "Help.com",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "bluebird": "~2.9",
     "lodash": "~2.4",
+    "object-path": "~0.9.0",
     "uuid": "~2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Message Object
Introduce a domain object for representing an ESB Message.  This breaks compatibility with previous versions, primarily with the places where messages are sent back to the calling code as it is no longer returning the `data`, but the entire message in a message object.

When needed, a new MessageBuilder was created and is available at `client.mb` to facilitate building the messages and linking them properly for the ESB.

The new Message objects also expose functionality from [object-path](https://github.com/mariocasciaro/object-path) to make them easier to work with.

This change was made primarily for the purpose of providing an object that we can add new functionality to.  POJO's are simple, but they bloat the API of this library and make it harder to add more state-based behaviors.

## Inre ESB Message Tracing
Like the docs say below, this provides a mechanism for tracing a single call to some ESB service down into secondary/tertiary/n-ary services that were made in order to fulfill the original request.

This provides an interesting capability to the ESB where we can more easily tell the true weight of service calls, but it does require the clients to utilize the field properly to work.

A preferred way of implementing this was to alter the rpcReceive callback call to pass a proxy client that knew to pass the inre flag on its otherwise-unmodified send/rpcSend methods.  This would have been a clean way of doing things, but unfortunately there doesn't seem to be a way to do this yet and our best hope is ecmascript 6 Proxy handlers. Instead, this less ideal method was attempted that requires a new parameter on the send/rpcSend calls.