### PR TITLE
Fix bugs with non-object data.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "help-esb",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A client for the Help.com team's ESB.",
   "main": "help-esb.js",
   "author": "Help.com",


### PR DESCRIPTION
Services aren't required to return objects back for data.  The data is allowed to be arrays, strings, etc.  This was not being handled correctly by the extend logic which was converting everything to an object according to _.extend rules.

For arrays, concatenation makes a good expectation for extending.  So if we see an array in any of the messages being merged together, then use array concatenation to determine the result data.

For other types of data that isn't an object, just grab the last one found (extend gives precedence to last objects passed).  There's no good default for merging multiples here, so we just use a simple order-based precedence.

Undefined values of data are ignored.  So if there are any defined values, they will be grabbed instead of setting data to undefined.