### PR TITLE
Send rpc replies directly to the caller's channel id.

### DIFF
--- a/help-esb.js
+++ b/help-esb.js
@@ -134,8 +134,9 @@
   // and relies on the other service properly publishing a message with a
   // proper replyTo.
   //
-  // Automatically subscribes to the result group for you if not already
-  // subscribed.
+  // Assumes that the calling service will send a reply back to your channel id
+  // so that you automatically get the reply.  If that's not the case, you may
+  // need to subscribe to the result channel.
   //
   //     client.rpcSend('foo', {name: 'John'})
   //       .then(function(response) {
@@ -145,9 +146,7 @@
   //       });
   HelpEsb.Client.prototype.rpcSend = function(group, message, inre) {
     var send = Promise.promisify(HelpEsb.Client.prototype.send).bind(this);
-    return this.subscribe(group + '-result').then(function() {
-      return send(group, message, inre).then(this._checkRpcResult);
-    }.bind(this));
+    return send(group, message, inre).then(this._checkRpcResult);
   };
 
   // ### HelpEsb.Client.rpcReceive
@@ -179,6 +178,7 @@
       var meta = {
         type: 'sendMessage',
         replyTo: message.getMeta('id'),
+        channel: message.getMeta('from'),
         inre: message.getMeta('id')
       };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "help-esb",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A client for the Help.com team's ESB.",
   "main": "help-esb.js",
   "author": "Help.com",


### PR DESCRIPTION
Right now, our services have to subscribe (automatically) to the SERVICE-result groups.  This leads to popular RPC services having their responses duplicated and sent to a ton of channels that don't actually need them.

We do still want to have SERVICE-result groups, however, as they can be useful for some cases (like the -sonar services).  We just need to provide a way for RPC transactions to happen without having to subscribe to the SERVICE-result groups.

We have actually had the mechanism we need for this for a while.  Channels are already uniquely identified by an id and send that id as their "from" id in the meta.  We can also direct a message to that channel by using its id in a "channel" id in the meta.

By adding the "channel" id, the calling service gets the message directly and we can remove the "-result" subscription (assuming all services follow this pattern).

One important note, is that if you do subscribe to the SERVICE-result group and send rpc calls to the SERVICE group, the ESB will send the reply back twice (once for the "channel" header and once for the "group" header.  Assuming you used `rpcSend` to send the request, though, even that may not matter as `rpcSend` and Promises use `.once` style behavior that will only resolve a single time.