### PR TITLE
Add newrelic support for rpcReceive.

### DIFF
--- a/help-esb.js
+++ b/help-esb.js
@@ -50,6 +50,12 @@
   //       // Process message
   //       return result;
   //     });
+  //
+  // Supported options:
+  // * `debug`: This logs messages to the console.
+  // * `newrelic`: This option can be set as an instance of the newrelic agent.
+  //   RPC requests received by this client will be wrapped in a newrelic
+  //   transaction named after the group.
   HelpEsb.Client = function(uri, options) {
     // Extend EventEmitter to handle events.
     EventEmitter.call(this);
@@ -60,7 +66,7 @@
     this._authentication = null;
     this._subscriptions = {};
     this._login = null;
-    this._options = _.extend({debug: false}, options);
+    this._options = _.extend({debug: false, newrelic: null}, options);
 
     this.mb = new HelpEsb.MessageBuilder(this);
   };
@@ -173,8 +179,9 @@
   //       throw new Error('Not implemented!');
   //     });
   HelpEsb.Client.prototype.rpcReceive = function(group, cb) {
+    var newrelic = this._options.newrelic;
     this.subscribe(group);
-    this.on('group.' + group, function(message) {
+    var messageHandler = function(message) {
       var meta = {
         type: 'sendMessage',
         replyTo: message.getMeta('id'),
@@ -202,19 +209,53 @@
         return Promise.all(groups.map(_.partial(sendToGroup, message)));
       };
 
-      Promise.try(cb.bind({}, message)).then(function(message) {
+      var execute = Promise.try(cb.bind({}, message)).then(function(message) {
         return sendToAll(
           this.mb.success(
             this.mb.extend({meta: meta}, this.mb.coerce(message))
           )
         );
-      }.bind(this)).catch(function(error) {
+      }.bind(this));
+
+      var errorHandler = function(error) {
         var reason = _.isError(error) ? error.toString() : error;
         var errorMeta = _.extend({reason: reason}, meta);
 
+        if (newrelic !== null) {
+          newrelic.noticeError(
+            _.isError(error) ? error : ('' + error),
+            message.toJSON()
+          );
+        }
+
         return sendToAll(this.mb.failure({meta: errorMeta}));
-      }.bind(this));
-    }.bind(this));
+      }.bind(this);
+
+      if (newrelic !== null) {
+        errorHandler = newrelic.agent.tracer.bindFunction(
+          errorHandler,
+          newrelic.agent.tracer.segment
+        );
+      }
+
+      execute = execute.catch(errorHandler);
+
+      if (newrelic !== null) {
+        execute.finally(newrelic.agent.tracer.bindFunction(
+          newrelic.endTransaction.bind(newrelic),
+          newrelic.agent.tracer.segment
+        ));
+      }
+    }.bind(this);
+
+    if (newrelic !== null) {
+      messageHandler = newrelic.createBackgroundTransaction(
+        group,
+        messageHandler
+      );
+    }
+
+    this.on('group.' + group, messageHandler);
   };
 
   // ### HelpEsb.Client.close

--- a/help-esb.js
+++ b/help-esb.js
@@ -209,7 +209,7 @@
           )
         );
       }.bind(this)).catch(function(error) {
-        var reason = error instanceof Error ? error.toString() : error;
+        var reason = _.isError(error) ? error.toString() : error;
         var errorMeta = _.extend({reason: reason}, meta);
 
         return sendToAll(this.mb.failure({meta: errorMeta}));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "help-esb",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "A client for the Help.com team's ESB.",
   "main": "help-esb.js",
   "author": "Help.com",


### PR DESCRIPTION
rpcReceive handlers are the only ones that can be properly wrapped in a newrelic transaction.  Others would require custom implementation in the calling code as the esb client can't know when the transaction ends.

This is currently using a background transaction as that is more correct semantically.  I'm not positive the features in newrelic are as nice for background transactions, however, so we may want to switch to a web transaction in the future, even if that means hacking things into place.

Errors will be sent to newrelic as well.  Included will be the original message for help with debugging what happened.

The newrelic instrumentation is a bit weird.  There doesn't seem to be support for bluebird promises in newrelic's agent and because of the magicalness of newrelic's transaction tracing, there's not a lot we can do about it.  It's possible to use newrelic.createTracer() around the error handler and finally clause, but that seemed to double/treble up the time taken in the transaction which is not what we want (it was reporting time for the error handler even when it wasn't running). Instead, I dig a little below newrelic's surface API and manually bind the function to the active transaction segment.  I'm fairly certain this should work, even in the presence of concurrent transactions, but I'm not 100% positive.  This also has the downside of possibly breaking on new versions of the newrelic agent.  We'll have to be careful when upgrading the newrelic agent to make sure things continue working.