### PR TITLE
Handle heartbeats and clean up logs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "help-esb",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "A client for the Help.com team's ESB.",
   "main": "help-esb.js",
   "author": "Help.com",


### PR DESCRIPTION
Heartbeats are used by the ESB to determine when a service has gone offline.  They are super simple to implement: just a simple reply that is sent in all cases.

I decided to go through the normal channels for handling these (by using the EventEmitter interface) as I dislike special cases.  This could just as easily be implemented outside of help-esb entirely.

Heartbeats are a new type of message rather than being a standard `sendMessage`.  This helps keep them small but does mean that they need to be treated differently, especially with how this reply is formed.